### PR TITLE
Add missing compactInteger function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Alias for `intComma`
 Converts a large integer to a friendly text representation.
 This method is now a thin wrapper around compactInteger
 
-`Humanize.intword(num, ch, de) === Humanize(num, de)`
+`Humanize.intword(num, ch, de) === Humanize.compactInteger(num, de)`
 
 ```javascript
 Humanize.intword(123456789, 'nopnopnopnop', 1)


### PR DESCRIPTION
The docs seemed to suggest that `Humanize` itself was a function when I believe this was meant to call `Humanize.compactInteger` instead.
