### PR TITLE
Less -> fewer grammar fix for numerable items

### DIFF
--- a/src/humanize.js
+++ b/src/humanize.js
@@ -404,7 +404,7 @@
 
       // Use the last time unit if there is nothing smaller
       if (!timeUnit) {
-        prefix = 'Less than';
+        prefix = 'Fewer than';
         relativePace = 1;
         timeUnit = TIME_FORMATS[TIME_FORMATS.length - 1].name;
       }


### PR DESCRIPTION
When comparing a smaller quantity of innumerable stuff (e.g snow), "less" (e.g. less snow) is appropriate. When comparing a smaller quantity of things that are numerable (e.g. units), "fewer" (e.g. fewer units) is correct.