### PR TITLE
Have ordinal return 0th instead of 0

### DIFF
--- a/__tests__/humanize.spec.js
+++ b/__tests__/humanize.spec.js
@@ -45,8 +45,8 @@ describe('compactInteger tests', () => {
 
 describe('Ordinal value of numbers Test Suite', () => {
   describe('Ordinal value for numbers ending in zero', () => {
-    it('should return 0 if the number is 0 (cos 0th doesnt read very well)', () => {
-      expect(Humanize.ordinal(0)).toEqual(0);
+    it('should return 0th if the number is 0', () => {
+      expect(Humanize.ordinal(0)).toEqual('0th');
     });
 
     it('should return the number with suffix th', () => {

--- a/src/humanize.js
+++ b/src/humanize.js
@@ -220,10 +220,6 @@
     ordinal(value) {
       const number = parseInt(value, 10);
 
-      if (number === 0) {
-        return value;
-      }
-
       const specialCase = number % 100;
       if ([11, 12, 13].indexOf(specialCase) >= 0) {
         return `${ number }th`;


### PR DESCRIPTION
Both [dictionary.com](http://www.dictionary.com/browse/zeroth) and [wikipedia](https://en.wikipedia.org/wiki/0th) recognize 0th or zeroth, which makes this special case a bit weird to me