### PR TITLE
Using main from dist folder; updated version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "Nicholas Hwang <geek@nicholashwang.com> (http://github.com/geekjuice)"
   ],
   "description": "A simple utility library for making the web more humane.",
-  "main": "./src/humanize.js",
+  "main": "./dist/humanize.js",
   "keywords": [
     "humanize",
     "format"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "humanize-plus",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "homepage": "https://github.com/HubSpot/humanize",
   "authors": [
     "HubSpot <devteam@hubspot.com> (http://dev.hubspot.com)",


### PR DESCRIPTION
Using `main` from `dist` folder, avoids the need to transpile when using as bower package and makes it consistent with npm config, which also uses the dist version.
Updated version to 1.8.2, avoids mismatch when installing.