### PR TITLE
Compact Integer - Non Integer Case

### DIFF
--- a/__tests__/humanize.spec.js
+++ b/__tests__/humanize.spec.js
@@ -40,6 +40,12 @@ describe('compactInteger tests', () => {
     expect(Humanize.compactInteger(100)).toEqual('100');
     expect(Humanize.compactInteger(123456789, 1)).toEqual('123.5M');
   });
+  it('should fail for non-integer', () => {
+    const nonIntegerInput = '2.3'; // Example non-integer input
+    expect(() => {
+      Humanize.compactInteger(nonIntegerInput);
+    }).toThrowError('Input is not an integer.');
+  });
 });
 
 

--- a/src/humanize.js
+++ b/src/humanize.js
@@ -82,6 +82,11 @@
 
     // Converts an integer into its most compact representation
     compactInteger(input, decimals = 0) {
+
+      if (!Number.isInteger(input)) {
+        throw new Error('Input is not an integer.');
+      }
+
       decimals = Math.max(decimals, 0);
       const number = parseInt(input, 10);
       const signString = number < 0 ? '-' : '';


### PR DESCRIPTION
Tweaked `compactInteger` function to add a case for a non-integer input. Expect a failure in this case. Closes #98.